### PR TITLE
fix: prevent automatic redirection when renaming a chat.

### DIFF
--- a/templates/chat/chat_create.html
+++ b/templates/chat/chat_create.html
@@ -12,7 +12,14 @@
 
 <script>
     htmx.on('chatCreated', (event) => {
+        const chatId = event.detail.chatId;
+        document.getElementById('chat-container').setAttribute('data-chat-id', chatId);
         const url = event.detail.url;
         htmx.ajax('GET', url, '#chat-container');
+    });
+
+    htmx.on('updateID', (event) => {
+        const chatId = event.detail.chatId;
+        document.getElementById('chat-container').setAttribute('data-chat-id', chatId);
     });
 </script>

--- a/templates/chat/chat_edit.html
+++ b/templates/chat/chat_edit.html
@@ -12,6 +12,10 @@
 <script>
     htmx.on('chatUpdated', (event) => {
         const url = event.detail.url;
-        htmx.ajax('GET', url, '#chat-container');
+        const chatId = event.detail.chatId;
+        const currentChatId = parseInt(document.querySelector("#chat-container").getAttribute("data-chat-id"));
+        if (chatId === currentChatId) {
+            htmx.ajax('GET', url, '#chat-container');
+        }
     });
 </script>

--- a/templates/chat/chat_list.html
+++ b/templates/chat/chat_list.html
@@ -20,7 +20,7 @@
 
     <!-- Chat Container -->
     <div class="col-md-9">
-        <div id="chat-container">
+        <div id="chat-container" data-chat-id="">
             <div class="alert alert-info text-center mt-3">
                 Select or create a chat.
             </div>


### PR DESCRIPTION
fix:#3

This PR fixes the behavior where a user gets redirected to the renamed chat when they are not on the same chat they are renaming. After this fix, renaming a chat will no longer automatically redirect the user to the renamed chat, and they will remain on the chat they were previously viewing.

### How to test?
1. Open a chat that is not the one being renamed.
2. Rename a different chat from the sidebar or list.
3. Verify that the user stays on the chat they were viewing instead of being redirected to the renamed chat.

## Summary by Sourcery

Bug Fixes:
- Avoid redirecting users to a renamed chat if they are not currently viewing it.